### PR TITLE
issue#5: add confirmation popup for deleting a todo item

### DIFF
--- a/src/components/ConfirmationPopup.jsx
+++ b/src/components/ConfirmationPopup.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+function ConfirmationPopup({ message, onCancle, onConfirm }) {
+    return (
+        <div className="fixed inset-0 z-[999] flex items-center justify-center bg-gray-600 dark:bg-[#35373c] bg-opacity-50 dark:bg-opacity-50 transition-opacity duration-300 ease-in-out p-4">
+            <div className="flex flex-col gap-4 bg-white dark:bg-[#202124] dark:text-white p-4 rounded-lg shadow-lg transition-transform transform duration-300 ease-in-out w-full max-w-md">
+                <p>{message}</p>
+                <div className="flex justify-end flex-wrap space-x-2">
+                    <button
+                        onClick={onConfirm}
+                        className="flex justify-center items-center gap-1 bg-red-600 hover:bg-red-700 text-white px-4 py-1 rounded-lg active:scale-95"
+                    >
+                        Delete
+                    </button>
+                    <button
+                        onClick={onCancle}
+                        className="flex justify-center items-center gap-1 bg-[#35373c] hover:bg-[#2f3035] text-white px-4 py-1 rounded-lg active:scale-95"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default ConfirmationPopup

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -1,9 +1,12 @@
 import React, { useRef, useState } from 'react'
 import { useTodo } from '../contexts';
+import {ConfirmationPopup} from "./index"
 
 function TodoItem({ todo }) {
     const [isTodoEditable, setIsTodoEditable] = useState(false)
     const [todoMsg, setTodoMsg] = useState(todo.todo)
+    const [showConfirmation, setShowConfirmation] = useState(false)
+
     const { updateTodo, deleteTodo, toggleCompleted } = useTodo()
     const editRef = useRef(null)
 
@@ -20,8 +23,22 @@ function TodoItem({ todo }) {
         editRef.current.focus();
     }
 
+    // Delete functionality with delete confirmation popup
+    const handledelete = () => {
+        setShowConfirmation(true);
+    }
+
+    const handleCancelDelete = () => {
+        setShowConfirmation(false)
+    }
+    
+    const handleConfirmDelete = () => {
+        deleteTodo(todo.id)
+        setShowConfirmation(false)
+    }
 
     return (
+        <>
         <div
             className={`flex items-center border border-black/10 rounded-lg px-3 py-1.5 gap-x-3 shadow-sm shadow-white/50 dark:shadow-lg duration-300  text-black dark:text-white ${todo.completed ? "bg-[#c6e9a7] dark:bg-[#35373c47] " : "bg-[#ccbed7] dark:bg-[#35373c]"
                 }`}
@@ -59,11 +76,21 @@ function TodoItem({ todo }) {
             {/* Delete Todo Button */}
             <button
                 className="inline-flex w-8 h-8 rounded-lg shadow-md text-sm border border-black/10 justify-center active:scale-95 items-center bg-gray-50 dark:bg-[#2a2a2a] dark:hover:bg-[#303030]  shrink-0"
-                onClick={() => deleteTodo(todo.id)}
+                onClick={handledelete}
             >
                 <i className="fa-regular fa-trash-can text-red-500"></i>
             </button>
         </div>
+
+            {showConfirmation && (
+                <ConfirmationPopup
+                    message={"This action will delete this task. Are you sure to continue ?"}
+                    onConfirm={handleConfirmDelete}
+                    onCancle={handleCancelDelete}
+                />
+            )}
+
+        </>
     );
 }
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,5 +2,6 @@ import TodoForm from "./TodoForm";
 import TodoItem from "./TodoItem";
 import ThemeBtn from "./ThemeBtn";
 import Navbar from "./Navbar";
+import ConfirmationPopup from "./ConfirmationPopup";
 
-export { TodoForm, TodoItem, ThemeBtn, Navbar }
+export { TodoForm, TodoItem, ThemeBtn, Navbar, ConfirmationPopup}


### PR DESCRIPTION
This pull request implements a confirmation popup when the user clicks on the delete icon to delete a todo item. This ensures that users do not accidentally delete tasks.

Linked Issue: **Closes #5**